### PR TITLE
add all the primary regions to report on

### DIFF
--- a/monitoring/aws/lambda/periodic_lambda_function.py
+++ b/monitoring/aws/lambda/periodic_lambda_function.py
@@ -12,7 +12,12 @@ def lambda_handler(event, context):
     for region in event["regions"]:
         ec2client = boto3.client('ec2', region)
 
-        response = ec2client.describe_instances()
+        try:
+            response = ec2client.describe_instances()
+        except Exception as e:
+            print("Error fetching instances from region " + region)
+            print(e)
+            continue
         
         running_instances[region] = []
 
@@ -38,6 +43,9 @@ def build_instance_email_text(instances):
     buf = io.StringIO()
 
     for region in instances.keys():
+        if len(instances[region]) == 0:
+            continue
+
         buf.write("Region: {}\n".format(region))
         for instance in instances[region]:
             buf.write("{}\n".format(instance))

--- a/monitoring/aws/upload-lambda.yaml
+++ b/monitoring/aws/upload-lambda.yaml
@@ -58,7 +58,7 @@
       role: "{{ iam_role.iam_role.role_name }}"
       handler: periodic_lambda_function.lambda_handler
       region: "{{ default_region }}"
-      timeout: 15
+      timeout: 30
     register: lambda_func
 
   - debug:
@@ -82,7 +82,7 @@
       targets:
         - id: "{{ cloudwatch_rule_target_event_id }}"
           arn: "{{ lambda_func.configuration.function_arn }}"
-          input: ' {"regions": ["us-east-1", "us-east-2"], "emailregion": "{{ default_region }}", "recipients": {{ recipients | to_json }} , "fromemail": "{{ fromemail}}" } '
+          input: ' {"regions": ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "ap-east-1", "ap-south-1", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "eu-north-1", "me-south-1", "sa-east-1"], "emailregion": "{{ default_region }}", "recipients": {{ recipients | to_json }} , "fromemail": "{{ fromemail}}" } '
     register: event_info
 
   - debug:


### PR DESCRIPTION
extend the timeout for the lambda to 30 seconds (lots more queries with all the regions now)
when building the email report, do not report on empty regions
catch exceptions so the report goes out even if a region is failing the query