### PR TITLE
insert sleep before setting schedule

### DIFF
--- a/monitoring/aws/upload-lambda.yaml
+++ b/monitoring/aws/upload-lambda.yaml
@@ -70,6 +70,10 @@
       state: absent
       path: lambda.zip
 
+  - name: wait for lambda to settle so we can schedule against the latest version
+    pause:
+      seconds: 10
+
   - name: set event schedule
     cloudwatchevent_rule:
       name: "{{ cloudwatch_rule_name }}"


### PR DESCRIPTION
was seeing the cloudwatch event target a previous version of the lambda after running the playbook, so just sleep to give AWS a moment to register the newly updated lambda.