### PR TITLE
WIP: tag/build/publish hive releases

### DIFF
--- a/publishing/github.py
+++ b/publishing/github.py
@@ -1,0 +1,63 @@
+import json
+import os
+import requests
+
+class GitHubClient:
+    def __init__(self, user, repo, token=""):
+        gh_token = ""
+
+        if token != "":
+            gh_token = token
+        else:
+            if os.environ.get("GITHUB_TOKEN") != None:
+                gh_token = os.environ["GITHUB_TOKEN"]
+            if os.environ.get("GH_TOKEN") != None:
+                gh_token = os.environ["GH_TOKEN"]
+
+        if gh_token == "":
+            raise Exception("GitHub token not able to be set")
+
+        self.user = user
+        self.repo = repo
+        self.headers = {
+            'Authorization': 'token ' + gh_token,
+            'Accept': 'application/vnd.github.v3+json',
+        }
+    
+    def _create_request(self, rest_path):
+        return 'https://api.github.com' + rest_path
+
+    def create_annotated_tag(self, tag, tag_msg, commit_hash):
+        data = {
+            "tag": tag,
+            "message": tag_msg,
+            "object": commit_hash,
+            "type": "commit",
+        }
+
+        create_tag_rest_path = '/repos/{}/{}/git/tags'.format(self.user, self.repo)
+        req = self._create_request(create_tag_rest_path)
+
+        return requests.post(req, headers=self.headers, data=json.dumps(data))
+
+    def create_reference(self, ref, sha):
+        data = {
+            "ref": ref,
+            "sha": sha,
+        }
+
+        create_ref_rest_path = '/repos/{}/{}/git/refs'.format(self.user, self.repo)
+        req = self._create_request(create_ref_rest_path)
+
+        return requests.post(req, headers=self.headers, data=json.dumps(data))
+
+    def create_pr(self, pr_from, pr_to, pr_title):
+        data = {
+            "head": pr_from,
+            "base": pr_to,
+            "title": pr_title,
+        }
+
+        create_pr_rest_path = '/repos/{}/{}/pulls'.format(self.user, self.repo)
+        req = self._create_request(create_pr_rest_path)
+        return requests.post(req, headers=self.headers, data=json.dumps(data))

--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env /usr/bin/python
+ 
+import argparse
+import importlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import yaml
+
+GITHUB_CLIENT_USERNAME = "operator-framework"
+GITHUB_CLIENT_REPONAME = "community-operators"
+
+COMMUNITY_OPERATOR_MAIN_BRANCH = 'master'
+COMMUNITY_OPERATOR_DIR = 'community-operators/hive-operator'
+UPSTREAM_COMMUNITY_OPERATOR_DIR = 'upstream-community-operators/hive-operator'
+
+SUBPROCESS_REDIRECT = subprocess.DEVNULL
+
+def get_params():
+    parser = argparse.ArgumentParser(description='Publish new hive version to operator hub.')
+    parser.add_argument('--new-version', help='New hive release (eg 1.0.14)', required=True)
+    parser.add_argument('--repo-dir', help='Path to root of repo to commit operator bundle to', required=True)
+    parser.add_argument('--bundle-dir', help='Path to directory containing new operator bundle', required=True)
+    parser.add_argument('--verbose', help='Show more details while running', action='store_true', default=False)
+    
+    args = parser.parse_args()
+
+    repo_dir = args.repo_dir
+    if repo_dir == None:
+        repo_dir = os.getcwd()
+    
+    if args.verbose:
+        global SUBPROCESS_REDIRECT
+        SUBPROCESS_REDIRECT = None
+    return args
+
+def main():
+    params = get_params()
+    
+    # get to the right place on the filesystem
+    community_operator_repo_full_path = os.path.abspath(params.repo_dir)
+    os.chdir(community_operator_repo_full_path)
+
+    # get the local user's github username
+    cmd = "git ls-remote --get-url origin".split()
+    resp = subprocess.run(cmd, capture_output=True)
+    personal_gh_user, _ = get_github_repo_data(resp.stdout.decode('utf-8'))
+
+    print("Fetching latest upstream") 
+    cmd = "git fetch upstream".split()
+    resp = subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT)
+    if resp.returncode != 0:
+        print("failed to fetch upstream")
+        sys.exit(1)
+
+    print("Reset to upstream/master")
+    cmd = "git reset upstream/master".split()
+    resp = subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT)
+    if resp.returncode != 0:
+        print("Failed to set upstream/master")
+        sys.exit(1)
+
+    # community-operators
+    branch_name = 'add-community-hive-{}'.format(params.new_version)
+    pr_title = "Hive community operator {}".format(params.new_version)
+    open_pr(pr_title, personal_gh_user, branch_name, community_operator_repo_full_path, params.bundle_dir, COMMUNITY_OPERATOR_DIR, params.new_version)
+
+    # upstream-community-operators
+    branch_name = 'add-upstream-community-hive-{}'.format(params.new_version)
+    pr_title = "Hive upstream community operator {}".format(params.new_version)
+    open_pr(pr_title, personal_gh_user, branch_name, community_operator_repo_full_path, params.bundle_dir, UPSTREAM_COMMUNITY_OPERATOR_DIR, params.new_version)
+
+
+def open_pr(pr_title, gh_username, new_branch_name, repo_full_path, bundle_source_dir, bundle_target_dir_name, new_version):
+    print("Starting {}".format(pr_title))
+
+    # Starting branch
+    cmd = "git checkout {}".format(COMMUNITY_OPERATOR_MAIN_BRANCH).split()
+    resp = subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT, stderr=SUBPROCESS_REDIRECT)
+    if resp.returncode != 0:
+        print("Failed to switch to {} branch".format(COMMUNITY_OPERATOR_MAIN_BRANCH))
+        sys.exit(1)
+
+    print("Create branch {}".format(new_branch_name))
+    cmd = "git checkout -b {}".format(new_branch_name).split()
+    resp = subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT, stderr=SUBPROCESS_REDIRECT)
+    if resp.returncode != 0:
+        print("Faled to checkout branch {}".format(new_branch_name))
+        sys.exit(1)
+
+    # copy bundle directory
+    bundle_files = os.path.join(bundle_source_dir, new_version)
+    hive_dir = os.path.join(repo_full_path, bundle_target_dir_name, new_version)
+    shutil.copytree(bundle_files, hive_dir)
+
+    # update bundle manifest
+    bundle_manifests_file = os.path.join(repo_full_path, bundle_target_dir_name, "hive.package.yaml")
+    bundle = {}
+    with open(bundle_manifests_file, 'r') as a_file:
+        bundle = yaml.load(a_file, Loader=yaml.SafeLoader)
+
+    found = False
+    for channel in bundle["channels"]:
+        if channel["name"] == "alpha":
+            found = True
+            channel["currentCSV"] = "hive-operator.v{}".format(new_version)
+
+    if not found:
+        print("did not find a CSV channel to update")
+        sys.exit(1)
+
+    with open(bundle_manifests_file, 'w') as outfile:
+        yaml.dump(bundle, outfile, default_flow_style=False)
+
+    # commit files
+    cmd = "git add community-operators/hive-operator".split()
+    subprocess.run(cmd)
+
+    print("Commiting {}".format(pr_title))
+    cmd = 'git commit --signoff '.split()
+    cmd.append('--message="{}"'.format(pr_title))
+    subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT)
+
+    print("Pushing branch {}".format(new_branch_name))
+    cmd = 'git push origin {} --force'.format(new_branch_name).split()
+    resp = subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT, stderr=SUBPROCESS_REDIRECT)
+    if resp.returncode != 0:
+        print("failed to push branch to origin")
+        sys.exit(1)
+
+    # open PR
+    gh = importlib.import_module('github')
+    client = gh.GitHubClient(GITHUB_CLIENT_USERNAME, GITHUB_CLIENT_REPONAME, "")
+
+    from_branch = "{}:{}".format(gh_username, new_branch_name)
+    to_branch = COMMUNITY_OPERATOR_MAIN_BRANCH
+    
+    resp = client.create_pr(from_branch, to_branch, pr_title)
+    if resp.status_code != 201: #201 == Created
+        print(resp.text)
+        sys.exit(1)
+
+    json_content = json.loads(resp.content.decode('utf-8'))
+    print("PR opened: {}".format(json_content["html_url"]))
+
+# get_repo_data will take a git remote URL and decode
+# the github username and reponame from the URL
+def get_github_repo_data(repo_url):
+
+    user = ""
+    repo = ""
+
+    if repo_url.startswith("http"):
+        print("implement fetching username/reponame from http url")
+        sys.exit(1)
+    elif repo_url.startswith("git@"): # "git@github.com:USERNAME/REPONAME.git"
+        m = re.search('.*:([-0-9a-zA-Z_]+)/([-0-9a-zA-Z_]+).git', repo_url)
+        user = m.group(1)
+        repo = m.group(2)
+    else:
+        print("don't know how to unpack repo_url {}".format(repo_url))
+        sys.exit(1)
+        
+    return (user, repo)
+
+if __name__ == "__main__":
+    main()

--- a/publishing/tag-and-push-hive-release.py
+++ b/publishing/tag-and-push-hive-release.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env /usr/bin/python
+ 
+import argparse
+import importlib
+import json
+import os
+import subprocess
+
+GITHUB_CLIENT_USERNAME = "openshift"
+GITHUB_CLIENT_REPONAME = "hive"
+
+def get_params():
+    parser = argparse.ArgumentParser(description='Publish hive versions.')
+    parser.add_argument('--new-version', help='New hive release (eg 1.0.14)', required=True)
+    parser.add_argument('--new-commit-hash', help='Git commit ID associated with new version', required=True)
+    parser.add_argument('--repo-dir', help='Path to root of repo to checkout/build images from', required=True)
+    parser.add_argument('--registry-auth-file', help='Path to registry auth file (optional)')
+    
+    args = parser.parse_args()
+
+    repo_dir = args.repo_dir
+    if repo_dir == None:
+        repo_dir = os.getcwd()
+    
+    return args
+
+def build_image(repo_dir, registry_auth_file, tag):
+    prev_dir = os.getcwd()
+    os.chdir(repo_dir)
+
+    try:
+        # sync up git repo with remote
+        cmd = "git fetch upstream".split()
+        subprocess.run(cmd)
+        cmd = "git fetch upstream --tags".split()
+        subprocess.run(cmd)
+
+        # checkout tag/commit
+        cmd = 'git checkout {}'.format(tag).split()
+        subprocess.run(cmd)
+
+        container_name = 'quay.io/openshift-hive/hive:{}'.format(tag)
+
+        # build/push the thing
+        print("Building container")
+        cmd = 'buildah bud --tag {} -f ./Dockerfile'.format(container_name).split()
+        subprocess.run(cmd)
+
+        print("Pushing container")
+        cmd = 'buildah push '
+        if registry_auth_file != None:
+            cmd = cmd + ' --authfile={} '.format(registry_auth_file)
+        cmd = cmd + ' {}'.format(container_name)
+        subprocess.run(cmd.split())
+    finally:
+        os.chdir(prev_dir)
+
+def main():
+    params = get_params()
+
+    gh = importlib.import_module('github')
+    client = gh.GitHubClient(GITHUB_CLIENT_USERNAME, GITHUB_CLIENT_REPONAME, "")
+
+    # A tag is a combination of a a tag plus a reference
+    tag = 'v{}'.format(params.new_version)
+    tag_msg = 'hive {}'.format(params.new_version)
+
+    resp = client.create_annotated_tag(tag, tag_msg, params.new_commit_hash)
+    if not resp.ok:
+        print("Failed to tag: " + resp.text)
+        exit(1)
+
+    tag_sha = resp.json()["sha"]
+    # ref format for tags is 'refs/tags/<tag-name>'
+    tag_ref = 'refs/tags/{}'.format(tag)
+
+    resp = client.create_reference(tag_ref, tag_sha)
+    # Errors with "Reference already exists" if re-run with same version/hash
+    if not resp.ok and json.loads(resp.text).get("message") != "Reference already exists":
+        print("Failed to create tag reference: " + resp.text)
+        exit(1)
+
+    print("Created tag " + tag)
+
+    build_image(params.repo_dir, params.registry_auth_file, tag)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
script the steps to tag a hive release (by commit hash), and
building/uploading the image to an image registry.

Example:
GITHUB_TOKEN="token-that-can-tag-against-openshift/hive" ./tag-and-push-hive-release.py --new-version 1.1.1 --new-commit-hash
88dd9a38f6b8afaefa0e5cb92add0c9419dea0e5 --repo-dir /path/to/hive/repo
--registry-auth-file /path/to/auth/for/quay.io/openshift-hive/hive

This will:
1) interact directly with the GitHub API to create the necessary
tag and reference
2) fetching the latest remote 'upstream' code/tags
3) using buildah to build and push to
   quay.io/openshift-hive/hive:v<new-version>

script opening PR with new hive release on
operator-framework/community-operators

use existing bundle-creation scripts followed by: 

GITHUB_TOKEN=token_here ./publish-operator.py --new-version 1.1.1 --repo-dir
/path/to/local/checkout/of/community-operators --bundle-dir /path/to/OLM/bundle/dir

Where the OLM bundle dir was created using
openshift/hive/hack/generate-operator-bundle.py

This will:
1) create branches on your local community-operators (one for 
   community-operators one for upstream-community-operators)
2) push them
3) open PRs against operator-framework/community-operators
