### PR TITLE
ci-monitor: Add cleanup instructions to email report

### DIFF
--- a/monitoring/aws/lambda/ci_monitor_lambda_function.py
+++ b/monitoring/aws/lambda/ci_monitor_lambda_function.py
@@ -20,7 +20,15 @@ def parse_vpc(vpc):
     ret['datetime'] = datetime.datetime.utcfromtimestamp(int(hex_stamp, 16))
     ret['age'] = NOW - ret['datetime']
     ret['pr'] = int(hex_pr, 16)
+    ret['owned'] = get_owned_string(vpc)
     return ret
+
+
+def get_owned_string(o):
+    for tag in o.get('Tags', []):
+        if tag['Value'] == 'owned':
+            return f"{tag['Key']}=owned"
+    return None
 
 
 def get_tag_value(o, key=None):
@@ -85,6 +93,8 @@ def build_report_text(vpcs_by_region, debug=False):
                 buf.write(f"    Age: {int(h)}h{int(m)}m\n")
                 # NOTE: This won't dtrt for prow rehearsals :)
                 buf.write(f"    PR: https://github.com/openshift/hive/pull/{parsed['pr']}\n")
+                # You'll need to be logged into the right account for this to work
+                buf.write(f"    Cleanup (if you're lucky): hiveutil aws-tag-deprovision {parsed['owned']}\n")
 
         buf.write("\n")
         


### PR DESCRIPTION
Add a line to the email report from the CI monitor with the `hiveutil` command that will (usually) deprovision the cluster in question. Example (ignore "Age" -- I was debugging):

```
Region: us-east-1
  https://console.aws.amazon.com/vpc/home?region=us-east-1#VpcDetails:VpcId=vpc-0c3e18bcb9e66ad58
    Created: 2021-08-04 21:08:24
    Age: 0h59m
    PR: https://github.com/openshift/hive/pull/1486
    Cleanup (if you're lucky): hiveutil aws-tag-deprovision kubernetes.io/cluster/hiveci-610b01c8-5ce-k-6s84t=owned
```