### PR TITLE
Operatorhub publish rework

### DIFF
--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env /usr/bin/python
+#
+# Script to publish a Hive operatorhub bundle (generated separately) to both the
+# OpenShift OperatorHub repo (https://github.com/redhat-openshift-ecosystem/community-operators-prod)
+# as well as the Kubernetes OperatorHub repo (https://github.com/k8s-operatorhub/community-operators)
+#
+# The script will clone a fresh copy of each repo in a temporary directory.
+#
+# Example:
+#
+# GITHUB_TOKEN="YOUR-GITHUB-TOKEN" ./publish-operator.py --new-version 1.1.13 --bundle-dir /path/to/bundle --github-user myusername --verbose --dry-run
+#
 
 import argparse
 import importlib

--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -37,6 +37,7 @@ def get_params():
     parser.add_argument('--verbose', help='Show more details while running', action='store_true', default=False)
     parser.add_argument('--dry-run', help='Test run that skips pushing branches and submitting PRs', action='store_true', default=False)
     parser.add_argument('--update-channel', action='append', help='Update channel in OLM package to new version', required=True)
+    parser.add_argument('--wip', help='Adds work in progress "[WIP]" to resulting PRs, must be removed before they can merge', action='store_true', default=False)
 
     args = parser.parse_args()
 
@@ -54,16 +55,16 @@ def main():
         open_pr(work_dir,
                 "git@github.com:%s/community-operators-prod.git" % params.github_user,
                 "git@github.com:redhat-openshift-ecosystem/community-operators-prod.git",
-                params.github_user, params.bundle_dir, params.new_version, params.update_channel, params.dry_run)
+                params.github_user, params.bundle_dir, params.new_version, params.update_channel, params.wip, params.dry_run)
 
         # k8s-operatorhub/community-operators
         open_pr(work_dir,
                 "git@github.com:%s/community-operators.git" % params.github_user,
                 "git@github.com:k8s-operatorhub/community-operators.git",
-                params.github_user, params.bundle_dir, params.new_version, params.update_channel, params.dry_run)
+                params.github_user, params.bundle_dir, params.new_version, params.update_channel, params.wip, params.dry_run)
 
 
-def open_pr(work_dir, fork_repo, upstream_repo, gh_username, bundle_source_dir, new_version, update_channels, dry_run):
+def open_pr(work_dir, fork_repo, upstream_repo, gh_username, bundle_source_dir, new_version, update_channels, wip, dry_run):
 
     dir_name = fork_repo.split('/')[1][:-4]
 
@@ -109,6 +110,8 @@ def open_pr(work_dir, fork_repo, upstream_repo, gh_username, bundle_source_dir, 
 
     branch_name = 'update-hive-{}'.format(new_version)
     pr_title = "Update Hive community operator to {}".format(new_version)
+    if wip:
+        pr_title = "[WIP] %s" % pr_title
     print("Starting {}".format(pr_title))
 
     print("Create branch {}".format(branch_name))

--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -11,8 +11,6 @@ import sys
 import tempfile
 import yaml
 
-GITHUB_USER = "dgoodwin"
-
 GITHUB_CLIENT_USERNAME = "redhat-openshift-ecosystem"
 GITHUB_CLIENT_REPONAME = "community-operators-prod"
 
@@ -28,6 +26,7 @@ SUBPROCESS_REDIRECT = subprocess.DEVNULL
 def get_params():
     parser = argparse.ArgumentParser(description='Publish new hive version to operator hub.')
     parser.add_argument('--new-version', help='New hive release (eg 1.0.14)', required=True)
+    parser.add_argument('--github-user', help='Users github username, if different than $USER', default=os.environ["USER"])
     parser.add_argument('--bundle-dir', help='Path to directory containing new operator bundle', required=True)
     parser.add_argument('--verbose', help='Show more details while running', action='store_true', default=False)
     parser.add_argument('--dry-run', help='Test run that skips pushing branches and submitting PRs', action='store_true', default=False)
@@ -45,10 +44,10 @@ def main():
     with tempfile.TemporaryDirectory(prefix="operatorhub-push") as work_dir:
 
         # redhat-openshift-ecosystem/community-operators-prod
-        open_pr(work_dir, "git@github.com:%s/community-operators-prod.git" % GITHUB_USER, "community-operators-prod", GITHUB_USER, params.bundle_dir, HIVE_SUB_DIR, params.new_version, params.dry_run)
+        open_pr(work_dir, "git@github.com:%s/community-operators-prod.git" % params.github_user, "community-operators-prod", params.github_user, params.bundle_dir, HIVE_SUB_DIR, params.new_version, params.dry_run)
 
         # k8s-operatorhub/community-operators
-        open_pr(work_dir, "git@github.com:%s/community-operators.git" % GITHUB_USER, "community-operators", GITHUB_USER, params.bundle_dir, HIVE_SUB_DIR, params.new_version, params.dry_run)
+        open_pr(work_dir, "git@github.com:%s/community-operators.git" % params.github_user, "community-operators", params.github_user, params.bundle_dir, HIVE_SUB_DIR, params.new_version, params.dry_run)
 
 
 def open_pr(work_dir, fork_repo, dir_name, gh_username, bundle_source_dir, bundle_target_dir_name, new_version, dry_run):
@@ -70,9 +69,9 @@ def open_pr(work_dir, fork_repo, dir_name, gh_username, bundle_source_dir, bundl
     os.chdir(repo_full_path)
 
     # get the local user's github username
-    # cmd = "git ls-remote --get-url origin".split()
-    # resp = subprocess.run(cmd, capture_output=True)
-    # GITHUB_USER, _ = get_github_repo_data(resp.stdout.decode('utf-8'))
+    cmd = "git ls-remote --get-url origin".split()
+    resp = subprocess.run(cmd, capture_output=True)
+    github_user, _ = get_github_repo_data(resp.stdout.decode('utf-8'))
 
     cmd = "git remote add upstream git@github.com:redhat-openshift-ecosystem/community-operators-prod.git".split()
     resp = subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT)

--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -156,7 +156,7 @@ def open_pr(work_dir, fork_repo, upstream_repo, gh_username, bundle_source_dir, 
         client = gh.GitHubClient(GITHUB_CLIENT_USERNAME, GITHUB_CLIENT_REPONAME, "")
 
         from_branch = "{}:{}".format(gh_username, branch_name)
-        to_branch = COMMUNITY_OPERATOR_MAIN_BRANCH
+        to_branch = "main"
 
         resp = client.create_pr(from_branch, to_branch, pr_title)
         if resp.status_code != 201: #201 == Created

--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -44,10 +44,12 @@ def main():
     with tempfile.TemporaryDirectory(prefix="operatorhub-push") as work_dir:
 
         # redhat-openshift-ecosystem/community-operators-prod
-        open_pr(work_dir, "git@github.com:%s/community-operators-prod.git" % params.github_user, params.github_user, params.bundle_dir, params.new_version, params.dry_run)
+        open_pr(work_dir, "git@github.com:%s/community-operators-prod.git" % params.github_user,
+                params.github_user, params.bundle_dir, params.new_version, params.dry_run)
 
         # k8s-operatorhub/community-operators
-        open_pr(work_dir, "git@github.com:%s/community-operators.git" % params.github_user, params.github_user, params.bundle_dir, params.new_version, params.dry_run)
+        open_pr(work_dir, "git@github.com:%s/community-operators.git" % params.github_user,
+                params.github_user, params.bundle_dir, params.new_version, params.dry_run)
 
 
 def open_pr(work_dir, fork_repo, gh_username, bundle_source_dir, new_version, dry_run):
@@ -69,11 +71,6 @@ def open_pr(work_dir, fork_repo, gh_username, bundle_source_dir, new_version, dr
     repo_full_path = os.path.join(work_dir, dir_name)
     print("Working in %s" % repo_full_path)
     os.chdir(repo_full_path)
-
-    # get the local user's github username
-    cmd = "git ls-remote --get-url origin".split()
-    resp = subprocess.run(cmd, capture_output=True)
-    github_user, _ = get_github_repo_data(resp.stdout.decode('utf-8'))
 
     cmd = "git remote add upstream git@github.com:redhat-openshift-ecosystem/community-operators-prod.git".split()
     resp = subprocess.run(cmd, stdout=SUBPROCESS_REDIRECT)
@@ -177,26 +174,6 @@ def open_pr(work_dir, fork_repo, gh_username, bundle_source_dir, new_version, dr
     else:
         print("Skipping branch push due to dry-run")
     print()
-
-# get_repo_data will take a git remote URL and decode
-# the github username and reponame from the URL
-def get_github_repo_data(repo_url):
-
-    user = ""
-    repo = ""
-
-    if repo_url.startswith("http"):
-        print("implement fetching username/reponame from http url")
-        sys.exit(1)
-    elif repo_url.startswith("git@"): # "git@github.com:USERNAME/REPONAME.git"
-        m = re.search('.*:([-0-9a-zA-Z_]+)/([-0-9a-zA-Z_]+).git', repo_url)
-        user = m.group(1)
-        repo = m.group(2)
-    else:
-        print("don't know how to unpack repo_url {}".format(repo_url))
-        sys.exit(1)
-
-    return (user, repo)
 
 if __name__ == "__main__":
     main()

--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -22,9 +22,6 @@ import sys
 import tempfile
 import yaml
 
-GITHUB_CLIENT_USERNAME = "redhat-openshift-ecosystem"
-GITHUB_CLIENT_REPONAME = "community-operators-prod"
-
 # Hive dir within both:
 # https://github.com/redhat-openshift-ecosystem/community-operators-prod
 # https://github.com/k8s-operatorhub/community-operators
@@ -68,6 +65,9 @@ def main():
 def open_pr(work_dir, fork_repo, upstream_repo, gh_username, bundle_source_dir, new_version, dry_run):
 
     dir_name = fork_repo.split('/')[1][:-4]
+
+    dest_github_org = upstream_repo.split(':')[1].split('/')[0]
+    dest_github_reponame = dir_name
 
     os.chdir(work_dir)
 
@@ -164,7 +164,7 @@ def open_pr(work_dir, fork_repo, upstream_repo, gh_username, bundle_source_dir, 
 
         # open PR
         gh = importlib.import_module('github')
-        client = gh.GitHubClient(GITHUB_CLIENT_USERNAME, GITHUB_CLIENT_REPONAME, "")
+        client = gh.GitHubClient(dest_github_org, dest_github_reponame, "")
 
         from_branch = "{}:{}".format(gh_username, branch_name)
         to_branch = "main"

--- a/publishing/publish-operator.py
+++ b/publishing/publish-operator.py
@@ -44,13 +44,15 @@ def main():
     with tempfile.TemporaryDirectory(prefix="operatorhub-push") as work_dir:
 
         # redhat-openshift-ecosystem/community-operators-prod
-        open_pr(work_dir, "git@github.com:%s/community-operators-prod.git" % params.github_user, "community-operators-prod", params.github_user, params.bundle_dir, HIVE_SUB_DIR, params.new_version, params.dry_run)
+        open_pr(work_dir, "git@github.com:%s/community-operators-prod.git" % params.github_user, params.github_user, params.bundle_dir, params.new_version, params.dry_run)
 
         # k8s-operatorhub/community-operators
-        open_pr(work_dir, "git@github.com:%s/community-operators.git" % params.github_user, "community-operators", params.github_user, params.bundle_dir, HIVE_SUB_DIR, params.new_version, params.dry_run)
+        open_pr(work_dir, "git@github.com:%s/community-operators.git" % params.github_user, params.github_user, params.bundle_dir, params.new_version, params.dry_run)
 
 
-def open_pr(work_dir, fork_repo, dir_name, gh_username, bundle_source_dir, bundle_target_dir_name, new_version, dry_run):
+def open_pr(work_dir, fork_repo, gh_username, bundle_source_dir, new_version, dry_run):
+
+    dir_name = fork_repo.split('/')[1][:-4]
 
     os.chdir(work_dir)
 
@@ -115,12 +117,12 @@ def open_pr(work_dir, fork_repo, dir_name, gh_username, bundle_source_dir, bundl
     # copy bundle directory
     print("Copying bundle directory")
     bundle_files = os.path.join(bundle_source_dir, new_version)
-    hive_dir = os.path.join(repo_full_path, bundle_target_dir_name, new_version)
+    hive_dir = os.path.join(repo_full_path, HIVE_SUB_DIR, new_version)
     shutil.copytree(bundle_files, hive_dir)
 
     # update bundle manifest
     print("Updating bundle manfiest")
-    bundle_manifests_file = os.path.join(repo_full_path, bundle_target_dir_name, "hive.package.yaml")
+    bundle_manifests_file = os.path.join(repo_full_path, HIVE_SUB_DIR, "hive.package.yaml")
     bundle = {}
     with open(bundle_manifests_file, 'r') as a_file:
         bundle = yaml.load(a_file, Loader=yaml.SafeLoader)


### PR DESCRIPTION
Substantial refactor now that the openshift vs upstream repos were split.

Now will clone fresh copies of each rather than making any assumptions about using a working copy on your system. Added --dry-run for testing what will happen. Added --github-user for specifying your github username if different than your os. We use this combined with assumed fork names on that account.