### PR TITLE
Recognize `cdcci-` prefix for CI monitor lambda

### DIFF
--- a/monitoring/aws/lambda/ci_monitor_lambda_function.py
+++ b/monitoring/aws/lambda/ci_monitor_lambda_function.py
@@ -9,7 +9,9 @@ NOW = datetime.datetime.utcnow()
 
 # Our CI job is configured to use cluster names of the form:
 # hiveci-$timestamp-$pull
-NAME_FILTER = dict(Name='tag:Name', Values=['hiveci-*'])
+# and the e2e-pool test creates an additional cluster named:
+# cdcci-$timestamp-$pull
+NAME_FILTER = dict(Name='tag:Name', Values=['hiveci-*', 'cdcci-*'])
 # Where $timestamp is the number of seconds since the epoch, in hex; and
 # $pull is the PR number, also in hex.
 def parse_vpc(vpc):


### PR DESCRIPTION
We needed a way to recognize leaks of the additional cluster our e2e-pool test was creating. https://github.com/openshift/hive/pull/1942 makes that name the same as the original CLUSTER_NAME, but with a `cdcci-` prefix instead of `hiveci-`.