### PR TITLE
Change recipients to team alias

### DIFF
--- a/monitoring/aws/install-vars.json
+++ b/monitoring/aws/install-vars.json
@@ -1,12 +1,6 @@
 {
     "recipients": [
-        "abutcher",
-        "efried",
-        "jstuever",
-        "lleshchi",
-        "mold",
-        "mworthin",
-        "sumehta"
+        "openshift-hive-team"
     ],
     "fromemail": "openshift-hive-team",
     "email_domain": "redhat.com",


### PR DESCRIPTION
The mailing list seems to be working properly, so use it for recipients of bot notifications. This reduces toil for the joiner/leaver process as we can just curate the list behind that alias.

Note that this is still a list; if for some reason we needed to include a recipient who wasn't in the mailing list, we could.