### PR TITLE
Revert "Change recipients to team alias"

### DIFF
--- a/monitoring/aws/install-vars.json
+++ b/monitoring/aws/install-vars.json
@@ -1,6 +1,12 @@
 {
     "recipients": [
-        "openshift-hive-team"
+        "abutcher",
+        "efried",
+        "jstuever",
+        "lleshchi",
+        "mold",
+        "mworthin",
+        "sumehta"
     ],
     "fromemail": "openshift-hive-team",
     "email_domain": "redhat.com",


### PR DESCRIPTION
Reverts openshift-hive/hive-extras#23

We haven't been getting emails, and this is the only thing that changed recently. Maybe the mailing list is only accessible from inside RH?