### PR TITLE
ci-monitor: all-in-one cleanup command

### DIFF
--- a/monitoring/aws/lambda/ci_monitor_lambda_function.py
+++ b/monitoring/aws/lambda/ci_monitor_lambda_function.py
@@ -71,6 +71,7 @@ def lambda_handler(event, context):
 def build_report_text(vpcs_by_region, debug=False):
     buf = io.StringIO()
     count = 0
+    taglist = []
 
     for region, vpcs in vpcs_by_region.items():
         if isinstance(vpcs, Exception):
@@ -96,7 +97,9 @@ def build_report_text(vpcs_by_region, debug=False):
                 # NOTE: This won't dtrt for prow rehearsals :)
                 buf.write(f"    PR: https://github.com/openshift/hive/pull/{parsed['pr']}\n")
                 # You'll need to be logged into the right account for this to work
-                buf.write(f"    Cleanup (if you're lucky): hiveutil aws-tag-deprovision {parsed['owned']}\n")
+                buf.write(f"    Cleanup: hiveutil aws-tag-deprovision {parsed['owned']}\n")
+                taglist.append(parsed['owned'])
+        buf.write(f"\n\nfor tag in {' '.join(taglist)}; do hiveutil aws-tag-deprovision $tag; done")
 
         buf.write("\n")
         


### PR DESCRIPTION
Previously the CI leak email printed one cleanup command per leak. It still does that, but this commit adds a copy-pastable `for` loop that should be able to do it in one go. (Well, sequentially/synchronously, but you only have to copy-paste one thing.)